### PR TITLE
Fixed uninitialized m_swapchainIndex (#28)

### DIFF
--- a/vkhlf/src/FramebufferSwapchain.cpp
+++ b/vkhlf/src/FramebufferSwapchain.cpp
@@ -45,6 +45,7 @@ namespace vkhlf {
         std::shared_ptr<Allocator> const& swapchainAllocator,
         std::shared_ptr<Allocator> const& imageAllocator,
         std::shared_ptr<Allocator> const& imageViewAllocator)
+      : m_swapchainIndex(0)
     {
         vk::SurfaceCapabilitiesKHR surfaceCapabilities = device->get<PhysicalDevice>()->getSurfaceCapabilities(surface);
         assert(surfaceCapabilities.currentExtent.width != -1);


### PR DESCRIPTION
* Fixed uninitialized m_swapchainIndex

* Moved FramebufferSwapchain::m_swapchainIndex initialization to ctor definition